### PR TITLE
refactor: use `utils.get_function_to_code` in `to_pascal`

### DIFF
--- a/string_to_code/to_pascal.py
+++ b/string_to_code/to_pascal.py
@@ -31,29 +31,27 @@ _call_function_or_atom = utils.get_call_function_or_atom(
 )
 
 
-def function_to_code(in_function_id, in_function, **kwargs):
-    """
-    returns a string representing the code of the function/procedure
-    definiton in Pascal
-    """
-    assert isinstance(in_function, core.SimpleFunction)
+_body_to_str = utils.get_body_to_str("\n", "  ", _call_function_or_atom, "", "")
 
-    function_body = "\n".join(
-        "  " + _call_function_or_atom(_, **kwargs) for _ in in_function.called_list
-    )
-    if function_body:
-        assert function_body[-1] == ";"
-        function_body = function_body[:-1] + "\n"
 
-    function_name = _get_function_name(in_function_id, **kwargs)
+def _merge_to_full_function(in_function_name, in_function_body):
+    body_str = ""
+    if in_function_body:
+        assert in_function_body[-1] == ";"
+        body_str = in_function_body[:-1] + "\n"
     return "".join(
         [
-            f"procedure {function_name}();\n",
+            f"procedure {in_function_name}();\n",
             "begin\n",
-            function_body,
+            body_str,
             "end;",
         ]
     )
+
+
+_function_to_code = utils.get_function_to_code(
+    _get_function_name, _body_to_str, _merge_to_full_function
+)
 
 
 def _main_call_to_code(in_initial_call, **kwargs):
@@ -80,5 +78,5 @@ def _join_to_final(main_call, function_definitions, **_kwargs):
 
 
 proc_printer_program, proc = utils.get_all_proc_functions(
-    _main_call_to_code, function_to_code, _join_to_final
+    _main_call_to_code, _function_to_code, _join_to_final
 )


### PR DESCRIPTION
Continuation of #125.