### PR TITLE
docs: add examples illustrating usage of general `string_to_code`

### DIFF
--- a/examples/example_general.py
+++ b/examples/example_general.py
@@ -1,0 +1,14 @@
+"""
+this file illustrates the usage of the general string_to_code module
+"""
+import setup_examples  # noqa # pylint: disable=unused-import
+from string_to_code import string_to_code
+
+EXAMPLE_STR = "Hello, World!"
+TARGET_LANGUAGE = "ada"
+
+assert TARGET_LANGUAGE in string_to_code.get_target_languages()
+
+CODE = string_to_code.proc(TARGET_LANGUAGE, EXAMPLE_STR)
+
+print(f"{TARGET_LANGUAGE} code below prints '{EXAMPLE_STR}':\n{CODE}")

--- a/examples/example_list_available_languages.py
+++ b/examples/example_list_available_languages.py
@@ -1,0 +1,9 @@
+"""
+this file dsplays all available target languages
+"""
+import setup_examples  # noqa # pylint: disable=unused-import
+from string_to_code import string_to_code
+
+print("Available target languages:")
+for _ in sorted(string_to_code.get_target_languages()):
+    print(_)


### PR DESCRIPTION
Closes #163. Continuation of #164 and #165.