### PR TITLE
tests: add fortran90 examples

### DIFF
--- a/tests/unused_example_data/fortran90/function_used_twice.f90
+++ b/tests/unused_example_data/fortran90/function_used_twice.f90
@@ -1,0 +1,15 @@
+program main
+    implicit none
+    call fun_1()
+contains
+    subroutine fun_0()
+        write (*, "(A)", advance="no") "{"
+        write (*, "(A)", advance="no") "%"
+    end subroutine fun_0
+
+    subroutine fun_1()
+        call fun_0()
+        write (*, *)
+        call fun_0()
+    end subroutine fun_1
+end program main

--- a/tests/unused_example_data/fortran90/one_empty_function.f90
+++ b/tests/unused_example_data/fortran90/one_empty_function.f90
@@ -1,0 +1,12 @@
+program main
+    implicit none
+    call fun_1()
+contains
+    subroutine fun_0()
+    end subroutine fun_0
+
+    subroutine fun_1()
+        call fun_0()
+        write (*, "(A)", advance="no") "C"
+    end subroutine fun_1
+end program main

--- a/tests/unused_example_data/fortran90/single_atom.f90
+++ b/tests/unused_example_data/fortran90/single_atom.f90
@@ -1,0 +1,4 @@
+program main
+    implicit none
+    write (*, "(A)", advance="no") "X"
+end program main

--- a/tests/unused_example_data/fortran90/trivial.f90
+++ b/tests/unused_example_data/fortran90/trivial.f90
@@ -1,0 +1,3 @@
+program main
+    implicit none
+end program main


### PR DESCRIPTION
These files were formatted using [`fprettify`](https://github.com/fortran-lang/fprettify).

Related to #137.