### PR TITLE
fix: add explicit dev-dependency to `colorama`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ black = "25.1.0"
 mypy = "1.15.0"
 bandit = "1.8.2"
 xenon = "0.9.3"
+colorama = "0.4.6"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Same as:
- vil02/puzzle_generator#206.